### PR TITLE
Avoid quotes when the param type is String

### DIFF
--- a/src/rust/client_gen.rs
+++ b/src/rust/client_gen.rs
@@ -622,6 +622,15 @@ fn make_part(param: &Param) -> RustPrinter {
             + "::stream("
             + &param.name
             + r#").mime_str("application/octet-stream")?)"#
+    } else if param.tpe == DataType::String {
+        indent()
+            + r#".part(""#
+            + &param.original_name
+            + r#"", "#
+            + part_type
+            + "::text("
+            + &param.name
+            + r#".into()).mime_str("text/plain; charset=utf-8")?)"#
     } else {
         indent()
             + r#".part(""#


### PR DESCRIPTION
Currently golem-cli works sends request with quotes for String params. Therefore it inserts parameters wrongly, resulting in the following situation

```scala
golem-cli --golem-url http://localhost:8080/ worker connect --template-name \"my-template\" --worker-name myworker

Adding item ProductItem { product-id: "hmm", name: "hmm", price: 10.0, quantity: 2 } to the cart of user
```

vs

```scala
 golem-cli --golem-url http://localhost:8080/ worker connect --template-name my-template --worker-name myworker
Error: Can't find template $my-template
```

Consider this PR as a pointer to why this happens!

The main reason is `serde_json::to_string(str)` != `str` for primitive type String
