### PR TITLE
Feature: Run client generation with multiple OpenAPI specs 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,10 +18,12 @@ use openapiv3::OpenAPI;
 use std::path::Path;
 use std::result;
 
-mod merger;
+pub(crate) mod merger;
 pub(crate) mod printer;
 mod rust;
 mod toml;
+
+pub use merger::merge_all_openapi_specs;
 
 #[derive(Debug, Clone)]
 pub enum Error {
@@ -56,7 +58,7 @@ impl Error {
 pub type Result<T> = result::Result<T, Error>;
 
 pub fn gen(openapi_specs: Vec<OpenAPI>, target: &Path, name: &str, version: &str) -> Result<()> {
-    let open_api = merger::merge_all_openapi_specs(openapi_specs)?;
+    let open_api = merge_all_openapi_specs(openapi_specs)?;
 
     let src = target.join("src");
     let api = src.join("api");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ use openapiv3::OpenAPI;
 use std::path::Path;
 use std::result;
 
+mod merger;
 pub(crate) mod printer;
 mod rust;
 mod toml;
@@ -54,7 +55,9 @@ impl Error {
 
 pub type Result<T> = result::Result<T, Error>;
 
-pub fn gen(open_api: OpenAPI, target: &Path, name: &str, version: &str) -> Result<()> {
+pub fn gen(openapi_specs: Vec<OpenAPI>, target: &Path, name: &str, version: &str) -> Result<()> {
+    let open_api = merger::merge_all_openapi_specs(openapi_specs)?;
+
     let src = target.join("src");
     let api = src.join("api");
     let model = src.join("model");

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ use std::path::PathBuf;
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None, rename_all = "kebab-case")]
 struct Command {
-    #[arg(short, long, value_name = "spec", value_hint = clap::ValueHint::FilePath, num_args = 1..)]
+    #[arg(short, long, value_name = "spec", value_hint = clap::ValueHint::FilePath, num_args = 1.., required = true)]
     spec_yaml: Vec<PathBuf>,
 
     #[arg(short, long, value_name = "DIR", value_hint = clap::ValueHint::DirPath)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,7 +78,8 @@ fn main() {
 fn parse_openapi_specs(spec: &Vec<PathBuf>) -> Vec<OpenAPI> {
     spec.into_iter()
         .map(|spec| {
-            let file = File::open(&spec).unwrap();
+            let file =
+                File::open(&spec).expect(format!("Could not open file: {:?}", spec).as_str());
             let reader = BufReader::new(file);
             let openapi: OpenAPI = serde_yaml::from_reader(reader)
                 .expect(format!("Could not deserialize input: {:?}", spec).as_str());

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ struct MergeArgs {
     #[arg(short, long, value_name = "specs", value_hint = clap::ValueHint::FilePath, num_args = 1.., required = true)]
     spec_yaml: Vec<PathBuf>,
     #[arg(short, long, value_name = "output", value_hint = clap::ValueHint::FilePath)]
-    output_file: PathBuf,
+    output_yaml: PathBuf,
 }
 
 fn main() {
@@ -69,7 +69,7 @@ fn main() {
             let openapi_specs = parse_openapi_specs(&args.spec_yaml);
             let openapi =
                 golem_openapi_client_generator::merge_all_openapi_specs(openapi_specs).unwrap();
-            let file = File::create(&args.output_file).unwrap();
+            let file = File::create(&args.output_yaml).unwrap();
             serde_yaml::to_writer(file, &openapi).unwrap();
         }
     }

--- a/src/merger.rs
+++ b/src/merger.rs
@@ -1,0 +1,236 @@
+use indexmap::IndexMap;
+use openapiv3::{Components, ExternalDocumentation, OpenAPI, Paths};
+
+use crate::Error;
+
+pub(crate) fn merge_all_openapi_specs(openapi_specs: Vec<OpenAPI>) -> crate::Result<OpenAPI> {
+    if openapi_specs.is_empty() {
+        Err(Error::unexpected("No OpenAPI specs provided"))
+    } else if openapi_specs.len() == 1 {
+        Ok(openapi_specs.into_iter().next().unwrap())
+    } else {
+        let mut openapi_specs = openapi_specs;
+        let first = openapi_specs.pop().unwrap();
+        let rest = openapi_specs;
+        rest.into_iter().fold(Ok(first), |acc, open_api| {
+            if let Ok(acc) = acc {
+                merge_openapi_specs(acc, open_api)
+            } else {
+                acc
+            }
+        })
+    }
+}
+
+fn merge_openapi_specs(a: OpenAPI, b: OpenAPI) -> crate::Result<OpenAPI> {
+    let openapi_version = {
+        if a.openapi != b.openapi {
+            return Err(Error::unexpected("OpenAPI versions do not match"));
+        }
+        a.openapi
+    };
+
+    let info = {
+        if a.info != b.info {
+            return Err(Error::unexpected("Info objects do not match"));
+        }
+        a.info
+    };
+
+    let servers = {
+        if a.servers != b.servers {
+            return Err(Error::unexpected("Servers do not match"));
+        }
+        a.servers
+    };
+
+    let all_tags = {
+        let mut tags = a.tags;
+        let mut b_tags = b.tags;
+        tags.append(&mut b_tags);
+        tags
+    };
+
+    let all_paths = {
+        let Paths {
+            paths: a_paths,
+            extensions: a_extensions,
+        } = a.paths;
+        let Paths {
+            paths: b_paths,
+            extensions: b_extensions,
+        } = b.paths;
+        let all_paths = merge_unique(a_paths, b_paths);
+        let all_extensions = merge_unique(a_extensions, b_extensions);
+        Paths {
+            paths: all_paths,
+            extensions: all_extensions,
+        }
+    };
+
+    let components = merge_components(a.components, b.components);
+    let security = merge_unique_option_list(a.security, b.security);
+    let extensions = merge_unique(a.extensions, b.extensions);
+
+    let external_docs = merge_external_docs(a.external_docs, b.external_docs)?;
+
+    let result = OpenAPI {
+        openapi: openapi_version,
+        info,
+        servers,
+        paths: all_paths,
+        components,
+        security,
+        tags: all_tags,
+        extensions,
+        external_docs,
+    };
+
+    Ok(result)
+}
+
+fn merge_components(a: Option<Components>, b: Option<Components>) -> Option<Components> {
+    match (a, b) {
+        (Some(a), Some(b)) => {
+            let Components {
+                schemas: a_schemas,
+                responses: a_responses,
+                parameters: a_parameters,
+                examples: a_examples,
+                request_bodies: a_request_bodies,
+                headers: a_headers,
+                security_schemes: a_security_schemes,
+                links: a_links,
+                callbacks: a_callbacks,
+                extensions: a_extensions,
+            } = a;
+
+            let Components {
+                schemas: b_schemas,
+                responses: b_responses,
+                parameters: b_parameters,
+                examples: b_examples,
+                request_bodies: b_request_bodies,
+                headers: b_headers,
+                security_schemes: b_security_schemes,
+                links: b_links,
+                callbacks: b_callbacks,
+                extensions: b_extensions,
+            } = b;
+
+            let merged = Components {
+                schemas: merge_unique(a_schemas, b_schemas),
+                responses: merge_unique(a_responses, b_responses),
+                parameters: merge_unique(a_parameters, b_parameters),
+                examples: merge_unique(a_examples, b_examples),
+                request_bodies: merge_unique(a_request_bodies, b_request_bodies),
+                headers: merge_unique(a_headers, b_headers),
+                security_schemes: merge_unique(a_security_schemes, b_security_schemes),
+                links: merge_unique(a_links, b_links),
+                callbacks: merge_unique(a_callbacks, b_callbacks),
+                extensions: merge_unique(a_extensions, b_extensions),
+            };
+            Some(merged)
+        }
+        (Some(a), None) => Some(a),
+        (None, Some(b)) => Some(b),
+        (None, None) => None,
+    }
+}
+
+fn merge_external_docs(
+    a: Option<ExternalDocumentation>,
+    b: Option<ExternalDocumentation>,
+) -> crate::Result<Option<ExternalDocumentation>> {
+    let result = match (a, b) {
+        (Some(a), Some(b)) => {
+            let ExternalDocumentation {
+                description: a_description,
+                url: a_url,
+                extensions: a_extensions,
+            } = a;
+
+            let ExternalDocumentation {
+                description: b_description,
+                url: b_url,
+                extensions: b_extensions,
+            } = b;
+
+            let description = match (a_description, b_description) {
+                (Some(a), Some(b)) => {
+                    if a != b {
+                        return Err(Error::unexpected(
+                            "External documentation descriptions do not match",
+                        ));
+                    }
+                    Some(a)
+                }
+                (Some(a), None) => Some(a),
+                (None, Some(b)) => Some(b),
+                (None, None) => None,
+            };
+
+            let url = {
+                if a_url != b_url {
+                    return Err(Error::unexpected(
+                        "External documentation URLs do not match",
+                    ));
+                }
+                a_url
+            };
+
+            let extensions = merge_unique(a_extensions, b_extensions);
+
+            Some(ExternalDocumentation {
+                description,
+                url,
+                extensions,
+            })
+        }
+        (Some(a), None) => Some(a),
+        (None, Some(b)) => Some(b),
+        (None, None) => None,
+    };
+    Ok(result)
+}
+
+fn merge_unique_option_list<Key, Item>(
+    a: Option<Vec<IndexMap<Key, Item>>>,
+    b: Option<Vec<IndexMap<Key, Item>>>,
+) -> Option<Vec<IndexMap<Key, Item>>> {
+    match (a, b) {
+        (Some(a), Some(mut b)) => {
+            let mut result = a;
+            result.append(&mut b);
+            Some(result)
+        }
+        (Some(a), None) => Some(a),
+        (None, Some(b)) => Some(b),
+        (None, None) => None,
+    }
+}
+
+fn merge_unique<Key, Item>(
+    a: impl IntoIterator<Item = (Key, Item)>,
+    b: impl IntoIterator<Item = (Key, Item)>,
+) -> IndexMap<Key, Item>
+where
+    Key: std::fmt::Debug + Eq + std::hash::Hash,
+{
+    let mut map = IndexMap::new();
+    for (key, value) in a {
+        map.insert(key, value);
+    }
+    for (key, value) in b {
+        match map.entry(key) {
+            indexmap::map::Entry::Occupied(entry) => {
+                #[cfg(debug_assertions)]
+                println!("Entry is already occupied {:?}", entry.key());
+            }
+            indexmap::map::Entry::Vacant(entry) => {
+                entry.insert(value);
+            }
+        }
+    }
+    map
+}

--- a/src/merger.rs
+++ b/src/merger.rs
@@ -228,15 +228,17 @@ fn merge_unique<Key, Item>(
 ) -> Result<IndexMap<Key, Item>>
 where
     Key: std::fmt::Debug + Eq + std::hash::Hash,
-    Item: PartialEq,
+    Item: std::fmt::Debug + PartialEq,
 {
     for (key, value) in b {
         match a.entry(key) {
             indexmap::map::Entry::Occupied(entry) => {
                 if entry.get() != &value {
                     return Err(Error::unexpected(format!(
-                        "Duplicate key {:?} with different values",
-                        entry.key()
+                        "Duplicate key {:?} with different values \n Current {:?} \n New {:?}",
+                        entry.key(),
+                        entry.get(),
+                        value
                     )));
                 }
             }


### PR DESCRIPTION
- Client generation can now be used with multiple OpenAPI specs.
- Added separate command for merging without client generation.
   - `merge` and `generate` commands

